### PR TITLE
Move sign-update() to break listener

### DIFF
--- a/src/main/java/com/Acrobot/ChestShop/Listeners/Block/Break/SignBreak.java
+++ b/src/main/java/com/Acrobot/ChestShop/Listeners/Block/Break/SignBreak.java
@@ -63,6 +63,9 @@ public class SignBreak implements Listener {
     public static void onSignBreak(BlockBreakEvent event) {
         if (!canBlockBeBroken(event.getBlock(), event.getPlayer())) {
             event.setCancelled(true);
+            if (isSign(event.getBlock())) {
+                event.getBlock().getState().update();
+            }
         }
     }
 
@@ -118,7 +121,6 @@ public class SignBreak implements Listener {
         boolean canBeBroken = true;
 
         for (Sign sign : attachedSigns) {
-            sign.update();
 
             if (!canBeBroken || !ChestShopSign.isValid(sign)) {
                 continue;


### PR DESCRIPTION
(From it's own branch in favour of #5 which was on master)

When trying to push a chest shop sign with a piston you can trigger an infinite loop as the sign update seems to update the piston and call the piston's event again. Signs or blocks with attached signs shouldn't be able to be pushed with a piston anyways.

Also this sign update only was there to resend the text instantly to the player after the event was cancelled which won't happen with pistons. (Anymore? Not sure if that breaks downwards compatibility a litte bit, but this shouldn't be a huge feature)
